### PR TITLE
Fix file truncate build bug

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ file BUILD_FILE => FileList["src/compress.*", BUILD_DIR] do |bf|
   yaml = File.open("src/compress.yaml").read
   liquid = File.open("src/compress.liquid").read.gsub(/\s+/, " ").gsub(/\s+(?={)|/, "").gsub(/{% comment %}[^{]+{% endcomment %}/, "").strip
 
-  File.open bf.name, File::CREAT|File::WRONLY do |f|
+  File.open bf.name, 'w' do |f|
     f.puts yaml, "", liquid
   end
 end


### PR DESCRIPTION
The build process doesn't truncate the output file - as a result if a change is made that shortens the output the garbled remains of the previous file will be left at the end causing all tests to fail and me to pull my hair out. This PR prevents premature baldness.