### PR TITLE
Introduce the `startings` option

### DIFF
--- a/site/index.md
+++ b/site/index.md
@@ -8,6 +8,7 @@ A [Jekyll][jekyll] layout that compresses [HTML][html-spec]. At a glance:
 
 * removes unnecessary whitespace;
 * removes optional end tags;
+* removes optional start tags;
 * removes comments;
 * preserves whitespace within `<pre>`;
 * GitHub Pages compatible;
@@ -48,6 +49,7 @@ compress_html:
     envs: []
     whitespaces: []
   profile: false
+  startings: []
 ~~~
 
 ### clippings
@@ -104,6 +106,17 @@ compress_html:
   endings: all
 ~~~
 
+### startings
+
+An array of elements with [optional start tags][html-syntax]. These start tags will be removed.
+
+Example:
+
+~~~yaml
+compress_html:
+  endings: [html, head, body]
+~~~
+
 ## profile
 
 A boolean value to turn on the profile mode. If true, the layout creates a HTML table after the compressed content. The table contains the file size in bytes during the compressing steps.
@@ -157,6 +170,7 @@ compress_html:
     envs: [local]
     whitespaces: [LINE FEED]
   profile: true
+  startings: [html, head, body]
 ~~~
 
 ## Restrictions

--- a/site/index.md
+++ b/site/index.md
@@ -114,7 +114,7 @@ Example:
 
 ~~~yaml
 compress_html:
-  endings: [html, head, body]
+  startings: [html, head, body]
 ~~~
 
 ## profile

--- a/src/compress.liquid
+++ b/src/compress.liquid
@@ -25,6 +25,17 @@
 {% endif %}
 
 
+{% comment %}Remove start tags{% endcomment %}
+
+{% for _element in site.compress_html.startings %}
+  {% capture _start %}<{{ _element }}>{% endcapture %}
+  {% assign _content = _content | remove: _start %}
+{% endfor %}
+{% if _profile and site.compress_html.startings %}
+  {% assign _profile_startings = _content | size | plus: 1 %}
+{% endif %}
+
+
 {% comment %}Collapse whitespace outside of <pre>{% endcomment %}
 
 {% if site.compress_html.ignore.whitespaces %}
@@ -140,6 +151,9 @@
     <tr> <td>raw <td>{{ content | size }}
   {% if _profile_endings %}
     <tr> <td>endings <td>{{ _profile_endings }}
+  {% endif %}
+  {% if _profile_startings %}
+    <tr> <td>startings <td>{{ _profile_startings }}
   {% endif %}
   {% if _profile_collapse %}
     <tr> <td>collapse <td>{{ _profile_collapse }}

--- a/test/_startings.yml
+++ b/test/_startings.yml
@@ -1,0 +1,2 @@
+compress_html:
+  startings: [html, head]

--- a/test/expected/startings/body.html
+++ b/test/expected/startings/body.html
@@ -1,0 +1,1 @@
+<title>One</title><body>

--- a/test/expected/startings/head-html.html
+++ b/test/expected/startings/head-html.html
@@ -1,0 +1,1 @@
+<title>One</title>

--- a/test/expected/startings/head.html
+++ b/test/expected/startings/head.html
@@ -1,0 +1,1 @@
+<title>One</title>

--- a/test/source/startings/body.html
+++ b/test/source/startings/body.html
@@ -1,0 +1,5 @@
+---
+layout: compress
+---
+
+<title>One</title><body>

--- a/test/source/startings/head-html.html
+++ b/test/source/startings/head-html.html
@@ -1,0 +1,5 @@
+---
+layout: compress
+---
+
+<html><head><title>One</title>

--- a/test/source/startings/head.html
+++ b/test/source/startings/head.html
@@ -1,0 +1,5 @@
+---
+layout: compress
+---
+
+<head><title>One</title>

--- a/test/test_filter.rb
+++ b/test/test_filter.rb
@@ -50,6 +50,11 @@ class TestCompressed < Minitest::Test
     assert_dir "ignore_character_tabulation_space"
   end
 
+  def test_startings
+    jekyll_build ["_config.yml", "_startings.yml"]
+    assert_dir "startings"
+  end
+
   private
 
   EXPECTED_DIR = File.join File.dirname(__FILE__), "expected"


### PR DESCRIPTION
This should close #56. I choose the name `startings` instead of `openings` proposed by @jplitza, because the HTML spec uses the term *start* tag.