### PR TITLE
Release version 3

### DIFF
--- a/src/compress.yaml
+++ b/src/compress.yaml
@@ -1,6 +1,6 @@
 ---
 # Jekyll layout that compresses HTML
-# v2.1.0
+# v3.0.0
 # http://jch.penibelst.de/
 # © 2014–2015 Anatol Broder
 # MIT License


### PR DESCRIPTION
The breaking change is the cancelation of `ignore.whitespaces`. That’s why the new major number.