### PR TITLE
Fix inconsistancy with final blank line per pre

### DIFF
--- a/src/compress.liquid
+++ b/src/compress.liquid
@@ -85,9 +85,17 @@
   {% if _pres.size != 0 %}
     {% if site.compress_html.blanklines %}
       {% assign _lines = _pres.last | split: _LINE_FEED %}
+      {% assign _lastchar = _pres.last | split: "" | last %}
+      {% assign _outerloop = forloop %}
       {% capture _pres_after %}
         {% for _line in _lines %}
           {% assign _trimmed = _line | split: " " | join: " " %}
+          {% if forloop.last and _lastchar == _LINE_FEED %}
+            {% unless _outerloop.last %}
+              {{ _LINE_FEED }}
+            {% endunless %}
+            {% continue %}
+          {% endif %}
           {% if _trimmed != empty or forloop.last %}
             {% unless forloop.first %}
               {{ _LINE_FEED }}

--- a/test/expected/blanklines/blanklines.html
+++ b/test/expected/blanklines/blanklines.html
@@ -29,5 +29,9 @@
     </pre><pre>
     
     </pre>
+<pre>
+    
+    
+</pre>
 </body>
 </html>

--- a/test/source/blanklines/blanklines.html
+++ b/test/source/blanklines/blanklines.html
@@ -38,6 +38,19 @@ layout: compress
     
     </pre>
 
+
+    
+
+<pre>
+    
+    
+</pre>
+
 </body>
 
 </html>
+
+
+
+
+    


### PR DESCRIPTION
Fixes a newline/whitespace inconsistancy. Has no effect on final semantics but keeps the output in line with the input. Less than 0.1% performance impact in a brief test.