### PR TITLE
Fix pre issues

### DIFF
--- a/src/compress.liquid
+++ b/src/compress.liquid
@@ -85,24 +85,63 @@
   {% if _pres.size != 0 %}
     {% if site.compress_html.blanklines %}
       {% assign _lines = _pres.last | split: _LINE_FEED %}
-      {% assign _lastchar = _pres.last | split: "" | last %}
-      {% assign _outerloop = forloop %}
+
+      {% comment %}
+        This fancy section here is the only way to slice a string in liquid 2.
+        (At least that I know of)
+        I use this to determine whether the last line of this _pres.last is
+        leading up to the start of a pre (IE indentation) and it seems to be the
+        only way to reliably handle all the potential edge cases.
+      {% endcomment %}
+      {% assign _lastline = _lines.last.size %}
+      {% assign _lastline = _pres.last.size | minus: _lastline %}
+      {% assign _lastline = _pres.last | split: "" | shift: _lastline | join: "" %}
+      {% if _lastline == _lines.last %}
+        {% assign _lastline = true %}
+      {% else %}
+        {% assign _lastline = false %}
+      {% endif %}
+
       {% capture _pres_after %}
-        {% for _line in _lines %}
-          {% assign _trimmed = _line | split: " " | join: " " %}
-          {% if forloop.last and _lastchar == _LINE_FEED %}
-            {% unless _outerloop.last %}
-              {{ _LINE_FEED }}
-            {% endunless %}
-            {% continue %}
+        {% assign _firstchar = _pres.last | split: "" | first %}
+        {% if _firstchar == _LINE_FEED %}
+          {% assign _trimmed = _pres.last | split: " " | join: " " %}
+          {% if _trimmed == empty and forloop.last %}
+            {% assign _trimmed = true %}
+          {% else %}
+            {% assign _trimmed = false %}
           {% endif %}
-          {% if _trimmed != empty or forloop.last %}
-            {% unless forloop.first %}
+          {% unless forloop.first or _trimmed %}
+            {{ _LINE_FEED }}
+          {% endunless %}
+        {% endif %}
+
+        {% assign _outerloop = forloop %}
+        {% assign _firstline = true %}
+        {% for _line in _lines %}
+          {% assign _section_before_pre = false %}
+          {% if _lastline and forloop.last %}
+            {% unless _outerloop.last %}
+              {% assign _section_before_pre = true %}
+            {% endunless %}
+          {% endif %}
+          {% assign _trimmed = _line | split: " " | join: " " %}
+          {% if _trimmed != empty or _section_before_pre %}
+            {% unless _firstline %}
               {{ _LINE_FEED }}
             {% endunless %}
+            {% assign _firstline = false %}
             {{ _line }}
           {% endif %}
         {% endfor %}
+
+        {% assign _lastchar = _pres.last | split: "" | last %}
+        {% if _lastchar == _LINE_FEED %}
+          {% assign _trimmed = _pres.last | split: " " | join: " " %}
+          {% unless forloop.last or _trimmed == empty %}
+            {{ _LINE_FEED }}
+          {% endunless %}
+        {% endif %}
       {% endcapture %}
     {% else %}
       {% assign _pres_after = _pres.last | split: " " | join: " " %}

--- a/test/expected/blanklines/blanklines.html
+++ b/test/expected/blanklines/blanklines.html
@@ -29,6 +29,7 @@
     </pre><pre>
     
     </pre>
+<span>Text</span>
 <pre>
     
     

--- a/test/expected/blanklines/prepre.html
+++ b/test/expected/blanklines/prepre.html
@@ -1,0 +1,5 @@
+<div>
+TEXT
+<pre></pre>
+<pre></pre>
+</div>

--- a/test/source/blanklines/blanklines.html
+++ b/test/source/blanklines/blanklines.html
@@ -38,6 +38,9 @@ layout: compress
     
     </pre>
 
+    
+
+<span>Text</span>
 
     
 

--- a/test/source/blanklines/prepre.html
+++ b/test/source/blanklines/prepre.html
@@ -1,0 +1,12 @@
+---
+layout: compress
+---
+
+<div>
+
+TEXT
+<pre></pre>
+
+<pre></pre>
+
+</div>


### PR DESCRIPTION
Fixes #70 

Far slower performance with blanklines enabled though.

dab26c884e341b8f04d7389f7998965b2d1b9466 blanklines is correct as far as browser output goes (Extra whitespace is only in markup, not rendered) and is a whopping *twice* as fast as this version. (And faster than current master too) so perhaps it would be a better idea to just reset to that and ignore the whitespace inconsistancies.

Also, this shines light on the fact we need a second benchmark for blanklines mode - I'll get to work on that now