### PR TITLE
Blanklines: Revert pre changes, add testcases

### DIFF
--- a/src/compress.liquid
+++ b/src/compress.liquid
@@ -85,17 +85,9 @@
   {% if _pres.size != 0 %}
     {% if site.compress_html.blanklines %}
       {% assign _lines = _pres.last | split: _LINE_FEED %}
-      {% assign _lastchar = _pres.last | split: "" | last %}
-      {% assign _outerloop = forloop %}
       {% capture _pres_after %}
         {% for _line in _lines %}
           {% assign _trimmed = _line | split: " " | join: " " %}
-          {% if forloop.last and _lastchar == _LINE_FEED %}
-            {% unless _outerloop.last %}
-              {{ _LINE_FEED }}
-            {% endunless %}
-            {% continue %}
-          {% endif %}
           {% if _trimmed != empty or forloop.last %}
             {% unless forloop.first %}
               {{ _LINE_FEED }}

--- a/test/expected/blanklines/blanklines.html
+++ b/test/expected/blanklines/blanklines.html
@@ -29,9 +29,11 @@
     </pre><pre>
     
     </pre>
-<pre>
+<span>Text</span>
+    <pre>
     
     
 </pre>
 </body>
 </html>
+    

--- a/test/expected/blanklines/prepre.html
+++ b/test/expected/blanklines/prepre.html
@@ -1,0 +1,3 @@
+<div>
+TEXT<pre></pre><pre></pre>
+</div>

--- a/test/source/blanklines/blanklines.html
+++ b/test/source/blanklines/blanklines.html
@@ -38,6 +38,9 @@ layout: compress
     
     </pre>
 
+    
+
+<span>Text</span>
 
     
 

--- a/test/source/blanklines/prepre.html
+++ b/test/source/blanklines/prepre.html
@@ -1,0 +1,12 @@
+---
+layout: compress
+---
+
+<div>
+
+TEXT
+<pre></pre>
+
+<pre></pre>
+
+</div>


### PR DESCRIPTION
Fixes #70 (Introduced in dd5563b1f99bf0239bbaf8d6f09ac22b0a90bd97 v3.0.1)

Has a slight detrimental effect on output HTML but doesn't effect the browser's rendered output, and is 30% faster. Additionally, current master not only eats newlines but the entire line before unindented pre tags so it's an improvement.

I suggested an alternative in bcccb18f119615fa1ff4f5210340e07f4517ce15 for an extra 5% speedup but it adds some extra artefacts. If someone's using blanklines mode they're probably willing to put up the rare missing newline more than the 100% drop in performance suggested in #72 