### PR TITLE
Add benchmark for compression disabled

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,8 @@ task :performance => BUILD_FILE do
   require "benchmark"
   Dir.chdir "performance" do
     buildtimes = [
-      "Build:\t\t" + Benchmark.measure { sh "bundle exec jekyll build" }.to_s,
+      "Build:\t\t" + Benchmark.measure { sh "JEKYLL_ENV=performance bundler exec jekyll build" }.to_s,
+      "Compress:\t" + Benchmark.measure { sh "bundle exec jekyll build --config _config_compress.yml" }.to_s,
       "Blanklines:\t" + Benchmark.measure { sh "bundle exec jekyll build --config _config_blanklines.yml" }.to_s
     ]
     puts buildtimes

--- a/performance/_config.yml
+++ b/performance/_config.yml
@@ -1,6 +1,4 @@
 source: source
 compress_html:
-  clippings: [div]
-  comments: ["<!-- ", " -->"]
-  endings: [li, dt, dd, p, thead, tbody, tr, td, th]
-  profile: true
+  ignore:
+    envs: [performance]

--- a/performance/_config_compress.yml
+++ b/performance/_config_compress.yml
@@ -1,0 +1,6 @@
+source: source
+compress_html:
+  clippings: [div]
+  comments: ["<!-- ", " -->"]
+  endings: [li, dt, dd, p, thead, tbody, tr, td, th]
+  profile: true


### PR DESCRIPTION
A quick benchmark now shows build performance without compression,
with compression, and with blanklines compression:

```
Build:            0.000000   0.000000   0.480000 (  0.493244)
Compress:         0.000000   0.000000   6.650000 (  6.657062)
Blanklines:       0.000000   0.000000  10.230000 ( 10.248840)
```